### PR TITLE
Set experimentalDecorators to true for Deno decorators support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     }
   },
   "compilerOptions": {
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
   "importMap": "./import_map.json",


### PR DESCRIPTION
[Deno 1.40](https://deno.com/blog/v1.40) introduced support for TC39 stage 3 decorators. Causing following issue:
<img width="731" alt="Screenshot 2024-02-21 at 22 30 39" src="https://github.com/Savory/Danet-Starter/assets/36774784/8b9765c1-a401-4545-a0f5-85d8ad2b8cc4">

From mentioned release blog post:
> If you rely on the legacy “experimental TypeScript decorators”, you can still use them with the following configuration:

```json 
{
  "compilerOptions": {
    "experimentalDecorators": true
  }
}
```